### PR TITLE
Avoid Copies.

### DIFF
--- a/big-int/src/bigint.cpp
+++ b/big-int/src/bigint.cpp
@@ -66,7 +66,7 @@ largeInt::largeInt(long long nValue)
     this->number = std::to_string(nValue);
 }
 
-largeInt::largeInt(std::string nValue)
+largeInt::largeInt(const std::string& nValue)
 {
     // checks if input string starts with a minus and initializes object with input
     if (nValue.front() == '-')

--- a/big-int/src/bigint.hpp
+++ b/big-int/src/bigint.hpp
@@ -48,45 +48,45 @@ class largeInt
 
     explicit largeInt(int);
     explicit largeInt(long long int);
-    explicit largeInt(std::string);
+    explicit largeInt(const std::string&);
 
-    largeInt operator+(largeInt);
+    largeInt operator+(const largeInt&);
     largeInt operator+(int);
     largeInt operator+(int64_t);
 
-    largeInt operator-(largeInt);
+    largeInt operator-(const largeInt&);
     largeInt operator-(int);
     largeInt operator-(int64_t);
 
-    largeInt operator*(largeInt);
+    largeInt operator*(const largeInt&);
     largeInt operator*(int);
     largeInt operator*(int64_t);
 
-    largeInt operator/(largeInt);
+    largeInt operator/(const largeInt&);
     largeInt operator/(int);
     largeInt operator/(int64_t);
 
-    largeInt operator%(largeInt);
+    largeInt operator%(const largeInt&);
     largeInt operator%(int);
     largeInt operator%(int64_t);
 
-    largeInt &operator+=(largeInt);
+    largeInt &operator+=(const largeInt&);
     largeInt &operator+=(int);
     largeInt &operator+=(int64_t);
 
-    largeInt &operator-=(largeInt);
+    largeInt &operator-=(const largeInt&);
     largeInt &operator-=(int);
     largeInt &operator-=(int64_t);
 
-    largeInt &operator*=(largeInt);
+    largeInt &operator*=(const largeInt&);
     largeInt &operator*=(int);
     largeInt &operator*=(int64_t);
 
-    largeInt &operator/=(largeInt);
+    largeInt &operator/=(const largeInt&);
     largeInt &operator/=(int);
     largeInt &operator/=(int64_t);
 
-    largeInt operator%=(largeInt);
+    largeInt operator%=(const largeInt&);
     largeInt operator%=(int);
     largeInt operator%=(int64_t);
 
@@ -102,23 +102,23 @@ class largeInt
     bool operator==(int);
     bool operator==(int64_t);
 
-    bool operator!=(largeInt);
+    bool operator!=(const largeInt&);
     bool operator!=(int);
     bool operator!=(int64_t);
 
-    bool operator<(largeInt);
+    bool operator<(const largeInt&);
     bool operator<(int);
     bool operator<(int64_t);
 
-    bool operator>(largeInt);
+    bool operator>(const largeInt&);
     bool operator>(int);
     bool operator>(int64_t);
 
-    bool operator<=(largeInt);
+    bool operator<=(const largeInt&);
     bool operator<=(int);
     bool operator<=(int64_t);
 
-    bool operator>=(largeInt);
+    bool operator>=(const largeInt&);
     bool operator>=(int);
     bool operator>=(int64_t);
 


### PR DESCRIPTION
#### Description of Change
Changed most of the parameters to constant reference to avoid unnecessary copies of largeInt objects.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
This is just a minor change to avoid multiple largeInt constructions and copies. Fixes #51 